### PR TITLE
adding max concurency on SQS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hybridless/hybridless",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hybridless/hybridless",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "license": "GNU GPLv3",
       "dependencies": {
         "@babel/core": "^7.26.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hybridless/hybridless",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/options.ts
+++ b/src/options.ts
@@ -396,6 +396,7 @@ export interface OFunctionLambdaSQSEvent extends OFunctionEvent {
   queueBatchSize?: number
   maximumBatchingWindow?: number
   reportFailureResponse?: boolean
+  queueMaxConcurrency?: number
 }
 export interface OFunctionLambdaSNSEvent extends OFunctionEvent {
   protocol: OFunctionLambdaProtocol.sns

--- a/src/resources/FunctionLambdaContainerEvent.ts
+++ b/src/resources/FunctionLambdaContainerEvent.ts
@@ -158,6 +158,7 @@ export class FunctionLambdaContainerEvent extends FunctionContainerBaseEvent {
             ...((this.event as OFunctionLambdaSQSEvent).queueBatchSize ? { batchSize: (this.event as OFunctionLambdaSQSEvent).queueBatchSize } : {}),
             ...((this.event as OFunctionLambdaSQSEvent).maximumBatchingWindow ? { maximumBatchingWindow: (this.event as OFunctionLambdaSQSEvent).maximumBatchingWindow } : {}),
             ...((this.event as OFunctionLambdaSQSEvent).reportFailureResponse ? { functionResponseType: 'ReportBatchItemFailures' } : {}),
+            ...((this.event as OFunctionLambdaSQSEvent).queueMaxConcurrency ? { maximumConcurrency: (this.event as OFunctionLambdaSQSEvent).queueMaxConcurrency } : {}),
             	//ddbstreams
 						...((<OFunctionLambdaContainerEvent>this.event).protocol == OFunctionLambdaProtocol.dynamostreams ? { 
 							type: 'dynamodb',

--- a/src/resources/FunctionLambdaEvent.ts
+++ b/src/resources/FunctionLambdaEvent.ts
@@ -97,6 +97,7 @@ export class FunctionLambdaEvent extends FunctionBaseEvent<OFunctionLambdaEvent>
 						...((this.event as OFunctionLambdaSQSEvent).queueBatchSize ? { batchSize: (this.event as OFunctionLambdaSQSEvent).queueBatchSize } : {}),
 						...((this.event as OFunctionLambdaSQSEvent).maximumBatchingWindow ? { maximumBatchingWindow: (this.event as OFunctionLambdaSQSEvent).maximumBatchingWindow } : {}),
 						...((this.event as OFunctionLambdaSQSEvent).reportFailureResponse ? { functionResponseType: 'ReportBatchItemFailures' } : {}),
+						...((this.event as OFunctionLambdaSQSEvent).queueMaxConcurrency ? { maximumConcurrency: (this.event as OFunctionLambdaSQSEvent).queueMaxConcurrency } : {}),
 						//ddbstreams
 						...(this.event.protocol == OFunctionLambdaProtocol.dynamostreams ? { 
 							type: 'dynamodb',


### PR DESCRIPTION
Introducing max concurrency config for SQS to allow throttling on lambda execution

Issue: https://github.com/Hybridless/hybridless/issues/13